### PR TITLE
Fix temporary directory for `discord-ipc-*`

### DIFF
--- a/Sources/SwordRPC/SwordRPC.swift
+++ b/Sources/SwordRPC/SwordRPC.swift
@@ -51,12 +51,10 @@ public class SwordRPC {
     }
 
     public func connect() {
-        let bundleID = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? ""
-        let tempDir = NSTemporaryDirectory().replacingOccurrences(of: "\(bundleID)/", with: "")
-
+        let tempDir = FileManager.default.temporaryDirectory.path
 
         for ipcPort in 0 ..< 10 {
-            let socketPath = tempDir + "discord-ipc-\(ipcPort)"
+            let socketPath = tempDir + "/discord-ipc-\(ipcPort)"
             let localClient = ConnectionClient(pipe: socketPath)
             do {
                 try localClient.connect()


### PR DESCRIPTION
This change will require an update to PlayCover which I will write sometime soon. Sandboxing makes it so the iOS app is unable to access the user's temporary directory, which is where discord's IPC is located. This will repoint the temporary directory to the app's own temporary directory under `~/Library/Containers/[App ID]/Data/tmp`, in which the solution is the symlink the IPC "socket file" there. Requires https://github.com/PlayCover/PlayTools/pull/126 and https://github.com/PlayCover/PlayCover/pull/1130.